### PR TITLE
Fix DKIM signatures ending with a semicolon

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -50,6 +50,8 @@ class Validator extends DKIM
             $signatureToProcess = preg_replace('/\s+/', '', $signature);
             //Split into tags
             $dkimTags = explode(';', $signatureToProcess);
+            if(end($dkimTags) === '')
+                array_pop($dkimTags);
             foreach ($dkimTags as $tagIndex => $tagContent) {
                 [$tagName, $tagValue] = explode('=', trim($tagContent), 2);
                 unset($dkimTags[$tagIndex]);


### PR DESCRIPTION
a DKIM signature is allowed to end with a semicolon: 
See _tag-list_ on: https://tools.ietf.org/html/rfc6376#section-3.2

However, the validate() function throws a notice since it tries to split an empty string into an array
`PHP Notice:  Undefined offset: 1 in ..../src/Validator.php on line 56`
