### PR TITLE
Fixed "Notice:  Undefined offset: 1 in"

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -49,7 +49,7 @@ class Validator extends DKIM
             //Strip all internal spaces
             $signatureToProcess = preg_replace('/\s+/', '', $signature);
             //Split into tags
-            $dkimTags = explode(';', $signatureToProcess);
+            $dkimTags = explode(';', rtrim($signatureToProcess, ';'));
             //Drop an empty last element caused by a trailing semi-colon
             if (end($dkimTags) === '') {
                 array_pop($dkimTags);


### PR DESCRIPTION
Notice:  Undefined offset: 1 in C:\www\YetiForceCRM\vendor\phpmailer\dkimvalidator\src\Validator.php on line 52

example:
DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/relaxed;
	d=yetiforce.com; s=x; h=Date:Message-Id:From:Subject:To:Sender:Reply-To:Cc:
	MIME-Version:Content-Type:Content-Transfer-Encoding:Content-ID:
	Content-Description:Resent-Date:Resent-From:Resent-Sender:Resent-To:Resent-Cc
	:Resent-Message-ID:In-Reply-To:References:List-Id:List-Help:List-Unsubscribe:
	List-Subscribe:List-Post:List-Owner:List-Archive;
	bh=SJ6ymxy7WZs/fL2Y6ByGFRN1vQSwxLOXL/c62VERkXw=; b=QpFeZTxOgBHltXP0rId/YwYN2v
	eSmCDpovQZ9M49OSdt46+U5H4wF7/S/z49N0z7ZylNwiJR3Njo6VQ6LAkGftZEGNDeJtyFe3rHTFu
	sYIjGGXa473pUEFZOOJpdqXvAWqV2BfXshOqiEvpQApOQGE52wvfGgFzlm1r4lFbPYrGJaryF5o9y
	G7PFuA5rpLcq8vXn8AnHUSLJ0+JPCOh/UQYKeUMngI17rnYT1W5c3tNABgEoaCwsVunPJHziHZEnW
	8nBZsOLWigAdJ6TNF/wY7uXEQPBctzhxTlOeZY930emzPGCIDxz7vowyiHVTHvvPnniwxyjTzS+T5
	dH61F25w==;

the problem is with the last character