### PR TITLE
Fix canonicalization defaults ('Unknown body canonicalization algorithm: '), fixes #10

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -236,7 +236,7 @@ class Validator
                 $validationResult->addPass("Compatible DKIM version: ${dkimTags['v']}" . '.');
 
                 //Validate canonicalization algorithms for header and body
-                [$headerCA, $bodyCA] = explode('/', $dkimTags['c'], 2);
+                [$headerCA, $bodyCA] = explode('/', $dkimTags['c'], 2) + [1 => 'simple'];
                 if (
                     $headerCA !== self::CANONICALIZATION_HEADERS_RELAXED &&
                     $headerCA !== self::CANONICALIZATION_HEADERS_SIMPLE


### PR DESCRIPTION
Canonicalization algorithm "simple" must be interpreted as "simple/simple".
According to the RFC:

rfc4871-dkimbase.html#dkim-sig-hdr
rfc6376#section-3.5
..If only one algorithm is named, that algorithm is used for the header and "simple" is used for the body. For example, "c=relaxed" is treated the same as "c=relaxed/simple"...

I had a validaton error with a rapidmail newsletter due to this.

This trivial PR fixes the issue for me.